### PR TITLE
Fix elm tests

### DIFF
--- a/elm-files/Model.elm
+++ b/elm-files/Model.elm
@@ -1,0 +1,31 @@
+module Model exposing (Answer, VoteQuestion, questionDecoder)
+
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (decode, required)
+
+
+type alias Answer =
+    { text : String
+    , isSelected : Bool
+    , votes : Int
+    }
+
+type alias VoteQuestion =
+    { id : String
+    , text : String
+    , answers : List Answer
+    }
+
+answerDecoder : Decode.Decoder Answer
+answerDecoder =
+    decode Answer
+        |> required "text" Decode.string
+        |> required "isSelected" Decode.bool
+        |> required "votes" Decode.int
+
+questionDecoder : Decode.Decoder VoteQuestion
+questionDecoder =
+    decode VoteQuestion
+        |> required "id" Decode.string
+        |> required "text" Decode.string
+        |> required "answers" (Decode.list answerDecoder)

--- a/elm-files/Poll.elm
+++ b/elm-files/Poll.elm
@@ -5,7 +5,7 @@ import Html exposing (Attribute, Html, button, div, h1, h3, input, label, span, 
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import Style exposing (..)
-import Vote exposing (Answer, questionDecoder)
+import Model exposing (Answer, VoteQuestion, questionDecoder)
 import Json.Encode as Encode
 import Json.Decode as Decode
 import Random
@@ -130,7 +130,7 @@ type Msg
     = ChangeQuestion String
     | ChangeAnswer Int String
     | CreatePoll
-    | PollCreated (Result Http.Error Vote.Question)
+    | PollCreated (Result Http.Error VoteQuestion)
     | IdGenerated Int
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,6 +10,7 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "elm-community/elm-test": "4.1.1 <= v < 5.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,9 +9,12 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "elm-community/elm-test": "4.1.1 <= v < 5.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.1.0 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
related #33 

add new Model.elm file, which just (for now) contains models ** directly copied** from Vote.elm file so that Poll.elm could import Model instead of Vote. Future refactoring should put all models in the Model.elm file.